### PR TITLE
Enable quantity to support Dart 1 and Dart 2 API with dart2_constant

### DIFF
--- a/lib/number.dart
+++ b/lib/number.dart
@@ -9,6 +9,8 @@ library number;
 
 import 'dart:math';
 import 'dart:typed_data';
+import 'package:dart2_constant/math.dart' as polyfill_math;
+import 'package:dart2_constant/core.dart' as polyfill_core;
 
 part 'src/number/complex.dart';
 part 'src/number/double.dart';

--- a/lib/quantity_ext.dart
+++ b/lib/quantity_ext.dart
@@ -5,6 +5,8 @@ library quantity_ext;
 
 import 'dart:async';
 import 'dart:math';
+import 'package:dart2_constant/core.dart' as polyfill_core;
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:quantity/number.dart';
 import 'package:intl/intl.dart' show NumberFormat;
 import 'package:quantity/quantity_si.dart';

--- a/lib/quantity_si.dart
+++ b/lib/quantity_si.dart
@@ -7,6 +7,7 @@ library quantity_si;
 
 import 'dart:collection';
 import 'dart:math' as math;
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:quantity/number.dart';
 import 'package:logging/logging.dart';
 import 'package:intl/intl.dart' show NumberFormat;

--- a/lib/src/ext/permeability_ext.dart
+++ b/lib/src/ext/permeability_ext.dart
@@ -8,4 +8,4 @@ PermeabilityUnits newtonsPerAmpereSquared = Permeability.newtonsPerAmpereSquared
 // Constants.
 
 /// The magnetic permeability in a classical vacuum.
-const Permeability magneticConstant = const Permeability.constant(const Double.constant(4.0e-7 * pi));
+const Permeability magneticConstant = const Permeability.constant(const Double.constant(4.0e-7 * polyfill_math.pi));

--- a/lib/src/ext/solid_angle_ext.dart
+++ b/lib/src/ext/solid_angle_ext.dart
@@ -27,12 +27,12 @@ final SolidAngleUnits yoctosteradians = SolidAngle.steradians.yocto() as SolidAn
 
 final SolidAngleUnits spats = new SolidAngleUnits('spats', 'sp', null, null, 12.566371, false);
 
-final SolidAngleUnits spheres = new SolidAngleUnits('spheres', null, null, null, 4.0 * pi, false);
+final SolidAngleUnits spheres = new SolidAngleUnits('spheres', null, null, null, 4.0 * polyfill_math.pi, false);
 
-final SolidAngleUnits hemispheres = new SolidAngleUnits('hemispheres', null, null, null, 2.0 * pi, false);
+final SolidAngleUnits hemispheres = new SolidAngleUnits('hemispheres', null, null, null, 2.0 * polyfill_math.pi, false);
 
 /// 1/8th of a sphere (a spherical right triangle).
-final SolidAngleUnits octants = new SolidAngleUnits('octants', null, null, null, pi / 2.0, false);
+final SolidAngleUnits octants = new SolidAngleUnits('octants', null, null, null, polyfill_math.pi / 2.0, false);
 
 /// Same as [octants].
 final SolidAngleUnits sphericalRightTriangles = octants;

--- a/lib/src/ext/time_instant_ext.dart
+++ b/lib/src/ext/time_instant_ext.dart
@@ -55,7 +55,7 @@ final TimeInstantUnits TDB =
   // TDB = TAI + 32.184 + 0.001658sin(g) + 0.000014sin(2g)...
   // where g = 357.53 deg + 0.9856003(JD - 2451545.0) deg... (Julian dates are in the TAI time scale)
   final double d = val is num ? val.toDouble() : val is Number ? val.toDouble() : 0.0;
-  final double gRad = (357.53 + 0.9856003 * ((d / 86400.0) - 15341.0)) * (pi / 180.0);
+  final double gRad = (357.53 + 0.9856003 * ((d / 86400.0) - 15341.0)) * (polyfill_math.pi / 180.0);
   return new Double(d + 32.184 + 0.001658 * sin(gRad) + 0.000014 * sin(2.0 * gRad));
 }, (dynamic val) {
   // TAI = TDB - 32.184 - 0.001658sin(g) - 0.000014sin(2g)...
@@ -72,7 +72,7 @@ final TimeInstantUnits TDB =
   int count = 0;
   double tdbTest = TDB.fromMks(d).toDouble();
   double delta = tdbTest - taiTest;
-  double prevDelta = double.maxFinite;
+  double prevDelta = polyfill_core.double.maxFinite;
   while ((delta.abs() > epsilon) && (count < maxCount)) {
     // See if we got farther away (if so reverse and take smaller steps)
     if (delta.abs() > prevDelta.abs()) step *= -0.5;
@@ -118,7 +118,7 @@ final TimeInstantUnits TCB = new TimeInstantUnits(
   int count = 0;
   double tcbTest = TCB.fromMks(d).toDouble();
   double delta = tcbTest - taiTest;
-  double prevDelta = double.maxFinite;
+  double prevDelta = polyfill_core.double.maxFinite;
   while ((delta.abs() > epsilon) && (count < maxCount)) {
     // See if we got farther away (if so reverse and take smaller steps)
     if (delta.abs() > prevDelta.abs()) step *= -0.5;
@@ -154,7 +154,7 @@ final TimeInstantUnits UT1 =
   double tai = d;
   final double epsilon = 0.001;
   double deltaT = 0.0;
-  double lastDeltaT = double.maxFinite;
+  double lastDeltaT = polyfill_core.double.maxFinite;
   while (((deltaT - lastDeltaT).abs() > epsilon) && count < 100) {
     lastDeltaT = deltaT;
     tai = d - 32.184 + deltaT;
@@ -176,13 +176,13 @@ final TimeInstantUnits UT2 =
     new TimeInstantUnits('Universal Time (UT2)', null, 'UT2', null, 1.0, false, 0.0, (dynamic val) {
   //double d = val is num ? val.toDouble() : val is Number ? val.toDouble() : 0.0;
   final Number d = UT1.fromMks(val); // UT1
-  final double twoPI = 2.0 * pi;
+  final double twoPI = 2.0 * polyfill_math.pi;
   final double fourPI = 2.0 * twoPI;
   final double t = B.fromMks(UT1.toMks(d)).toDouble();
   return (d + (0.022 * sin(twoPI * t) - 0.012 * cos(twoPI * t) - 0.006 * sin(fourPI * t) + 0.007 * cos(fourPI * t)));
 }, (dynamic val) {
   double d = val is num ? val.toDouble() : val is Number ? val.toDouble() : 0.0;
-  final double twoPI = 2.0 * pi;
+  final double twoPI = 2.0 * polyfill_math.pi;
   final double fourPI = 2.0 * twoPI;
   final double t = B.fromMks(UT1.toMks(d)).toDouble(); // besselian -- use UT2 value as UT1... close enough
   d -= (0.022 * sin(twoPI * t) - 0.012 * cos(twoPI * t) - 0.006 * sin(fourPI * t) + 0.007 * cos(fourPI * t)); // UT1

--- a/lib/src/number/complex.dart
+++ b/lib/src/number/complex.dart
@@ -47,10 +47,10 @@ class Complex extends Number {
   Double get phase => complexArgument;
 
   @override
-  bool get isInfinite => real.value == double.infinity || real.value == double.negativeInfinity;
+  bool get isInfinite => real.value == polyfill_core.double.infinity || real.value == polyfill_core.double.negativeInfinity;
 
   @override
-  bool get isNaN => real.value == double.nan;
+  bool get isNaN => real.value == polyfill_core.double.nan;
 
   @override
   bool get isNegative => real.value < 0;

--- a/lib/src/number/double.dart
+++ b/lib/src/number/double.dart
@@ -9,11 +9,11 @@ class Double extends Real {
   static const Double ten = const Double.constant(10.0);
   static const Double hundred = const Double.constant(100.0);
   static const Double thousand = const Double.constant(1000.0);
-  static const Double infinity = const Double.constant(double.infinity);
-  static const Double negInfinity = const Double.constant(double.negativeInfinity);
+  static const Double infinity = const Double.constant(polyfill_core.double.infinity);
+  static const Double negInfinity = const Double.constant(polyfill_core.double.negativeInfinity);
 
   // ignore: constant_identifier_names
-  static const Double NaN = const Double.constant(double.nan);
+  static const Double NaN = const Double.constant(polyfill_core.double.nan);
 
   Double(this._value);
 
@@ -52,7 +52,7 @@ class Double extends Real {
 
   @override
   bool operator ==(dynamic obj) {
-    if (obj == double.nan) return value == double.nan;
+    if (obj == polyfill_core.double.nan) return value == polyfill_core.double.nan;
     if (obj is Real || obj is num) return obj == value;
     if (obj is Imaginary) return value == 0.0 && obj.value?.toDouble() == 0.0;
     if (obj is Complex) return obj.real?.toDouble() == value && obj.imaginary?.toDouble() == 0.0;

--- a/lib/src/number/imaginary.dart
+++ b/lib/src/number/imaginary.dart
@@ -172,7 +172,7 @@ class Imaginary extends Number {
 
   /// The complex argument, or phase, of this imaginary number in radians.
   ///
-  num get complexArgument => value < 0 ? -pi / 2.0 : pi / 2.0;
+  num get complexArgument => value < 0 ? -polyfill_math.pi / 2.0 : polyfill_math.pi / 2.0;
 
   /// The phase is synonymous with the complex argument.
   ///

--- a/lib/src/number/number.dart
+++ b/lib/src/number/number.dart
@@ -70,7 +70,7 @@ abstract class Number implements Comparable<dynamic> {
   /// Returns an `int` if this Number's value is an integer, a `double` otherwise.
   ///
   num get sign {
-    if (isNaN) return double.nan;
+    if (isNaN) return polyfill_core.double.nan;
     if (isNegative) return isInteger ? -1 : -1.0;
     if (toDouble() == 0) return isInteger ? 0 : 0.0;
     return isInteger ? 1 : 1.0;

--- a/lib/src/number/real.dart
+++ b/lib/src/number/real.dart
@@ -22,10 +22,10 @@ abstract class Real extends Number {
   double toDouble();
 
   @override
-  bool get isInfinite => value == double.infinity || value == double.negativeInfinity;
+  bool get isInfinite => value == polyfill_core.double.infinity || value == polyfill_core.double.negativeInfinity;
 
   @override
-  bool get isNaN => identical(value, double.nan);
+  bool get isNaN => identical(value, polyfill_core.double.nan);
 
   @override
   bool get isNegative => value < 0;

--- a/lib/src/si/types/angle.dart
+++ b/lib/src/si/types/angle.dart
@@ -12,7 +12,7 @@ double sine(Angle a) => a.sine();
 double tangent(Angle a) => a.tangent();
 
 // Constant
-const double twoPi = 2.0 * math.pi;
+const double twoPi = 2.0 * polyfill_math.pi;
 
 /// A planar (2-dimensional) angle, which has dimensions of _1_ and is a
 /// measure of the ratio of the length of a circular arc to its radius.
@@ -102,11 +102,11 @@ class Angle extends Quantity {
   /// If this Angle is already within that range then it is returned directly.
   ///
   Angle get angle180 {
-    if (valueSI >= -math.pi && valueSI <= math.pi) return this;
+    if (valueSI >= -polyfill_math.pi && valueSI <= polyfill_math.pi) return this;
 
     double rad = valueSI.toDouble();
-    while (rad < -math.pi) rad += twoPi;
-    while (rad > math.pi) rad -= twoPi;
+    while (rad < -polyfill_math.pi) rad += twoPi;
+    while (rad > polyfill_math.pi) rad -= twoPi;
     return new Angle(rad: rad);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ documentation: https://github.com/cooler-king/quantity/wiki
 environment:
   sdk: '>=2.0.0-dev.42 <2.0.0'
 dependencies:
+  dart2_constant: ^1.0.1+dart1
   intl: ^0.15.0
   logging: ^0.11.3
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,10 @@ author: Rob Bishop (cooler-king)
 homepage: https://github.com/cooler-king/quantity
 documentation: https://github.com/cooler-king/quantity/wiki
 environment:
-  sdk: '>=2.0.0-dev.42 <2.0.0'
+  sdk: '>=1.24.3 <=2.0.0'
 dependencies:
   dart2_constant: ^1.0.1+dart1
   intl: ^0.15.0
   logging: ^0.11.3
 dev_dependencies:
-  test: ^0.12.30
+  test: '>=0.12.30'

--- a/test/domain/electromagnetic_test.dart
+++ b/test/domain/electromagnetic_test.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:test/test.dart';
 import 'package:quantity/domain/electromagnetic.dart';
 
@@ -9,7 +9,7 @@ void main() {
       expect(elementaryCharge.valueSI.toDouble(), 1.6021766208e-19);
 
       expect(magneticConstant is Permeability, true);
-      expect(magneticConstant.valueSI.toDouble(), 4.0e-7 * pi);
+      expect(magneticConstant.valueSI.toDouble(), 4.0e-7 * polyfill_math.pi);
 
       expect(conductanceQuantum is Conductance, true);
       expect(conductanceQuantum.valueSI.toDouble(), 7.7480917310e-5);

--- a/test/domain/universal_test.dart
+++ b/test/domain/universal_test.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:test/test.dart';
 import 'package:quantity/domain/universal.dart';
 
@@ -12,7 +12,7 @@ void main() {
       expect(speedOfLightVacuum.valueSI.toDouble(), 2.99792458e8);
 
       expect(magneticConstant is Permeability, true);
-      expect(magneticConstant.valueSI.toDouble(), 4.0e-7 * pi);
+      expect(magneticConstant.valueSI.toDouble(), 4.0e-7 * polyfill_math.pi);
 
       expect(planckConstant is AngularMomentum, true);
       expect(planckConstant.valueSI.toDouble(), 6.626070040e-34);

--- a/test/number/double_test.dart
+++ b/test/number/double_test.dart
@@ -1,3 +1,4 @@
+import 'package:dart2_constant/core.dart' as polyfill_core;
 import 'package:test/test.dart';
 import 'package:quantity/quantity.dart';
 import 'package:quantity/number.dart';
@@ -12,16 +13,16 @@ void main() {
       expect(Double.ten.value, 10.0);
       expect(Double.hundred.value, 100.0);
       expect(Double.thousand.value, 1000.0);
-      expect(Double.infinity.value, double.infinity);
-      expect(Double.negInfinity.value, double.negativeInfinity);
-      expect(identical(Double.NaN.value, double.nan), true);
+      expect(Double.infinity.value, polyfill_core.double.infinity);
+      expect(Double.negInfinity.value, polyfill_core.double.negativeInfinity);
+      expect(identical(Double.NaN.value, polyfill_core.double.nan), true);
     });
 
     test('isNaN', () {
       final Double d = const Double.constant(42.0);
       final Double d2 = Double.NaN;
       final Double d3 = Double.infinity;
-      final Double d4 = new Double(double.nan);
+      final Double d4 = new Double(polyfill_core.double.nan);
 
       expect(d.isNaN, false);
       expect(d2.isNaN, true);

--- a/test/quantity/angle_test.dart
+++ b/test/quantity/angle_test.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:test/test.dart';
 import 'package:quantity/quantity.dart';
 import 'package:quantity/number.dart';
@@ -75,14 +75,14 @@ void main() {
       a = new Angle(deg: 90.0);
       expect(a, isNotNull);
       expect(a.valueSI is Double, true);
-      expect(a.valueSI.toDouble(), closeTo(pi / 2.0, 0.0001));
+      expect(a.valueSI.toDouble(), closeTo(polyfill_math.pi / 2.0, 0.0001));
       expect(a.dimensions, Angle.angleDimensions);
       expect(a.preferredUnits, Angle.degrees);
 
       // Default ctor: deg -
       a = new Angle(deg: -270);
       expect(a, isNotNull);
-      expect(a.valueSI.toDouble(), closeTo(-3 * pi / 2, 0.0001));
+      expect(a.valueSI.toDouble(), closeTo(-3 * polyfill_math.pi / 2, 0.0001));
       expect(a.valueSI is Double, true);
       expect(a.dimensions, Angle.angleDimensions);
       expect(a.preferredUnits, Angle.degrees);

--- a/test/quantity_range/angle_range_test.dart
+++ b/test/quantity_range/angle_range_test.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:test/test.dart';
 import 'package:quantity/quantity.dart';
 import 'package:quantity/quantity_range.dart';
@@ -20,12 +20,12 @@ void main() {
       expect(range.endAngle.valueSI.toDouble() == 0.9, true);
 
       range = new AngleRange.degrees(90.0, 180.0);
-      expect(range.startAngle.valueSI.toDouble(), closeTo(pi / 2, 0.0001));
-      expect(range.endAngle.valueSI.toDouble(), closeTo(pi, 0.0001));
+      expect(range.startAngle.valueSI.toDouble(), closeTo(polyfill_math.pi / 2, 0.0001));
+      expect(range.endAngle.valueSI.toDouble(), closeTo(polyfill_math.pi, 0.0001));
 
       range = new AngleRange.degrees(180.0, 90.0);
-      expect(range.startAngle.valueSI.toDouble(), closeTo(pi, 0.0001));
-      expect(range.endAngle.valueSI.toDouble(), closeTo(pi / 2, 0.0001));
+      expect(range.startAngle.valueSI.toDouble(), closeTo(polyfill_math.pi, 0.0001));
+      expect(range.endAngle.valueSI.toDouble(), closeTo(polyfill_math.pi / 2, 0.0001));
 
       range = new AngleRange.radians(1.72, 1.95);
       expect(range.startAngle.valueSI.toDouble() == 1.72, true);


### PR DESCRIPTION
I branched off of strong-mode (see above to verify my request is to merge this branch there) and replaced Dart 2 API's new constants with the same constants defined in dart2_constant.

This will allow quantity to still be able to run in Dart 2 and Dart 1.

Primarily, I used dart2_constant/core.dart and dart2_constant/math.dart, which I named polyfill_core and polyfill_math respectively, to avoid confusion with SDK API.