### PR TITLE
Fix Information constructor

### DIFF
--- a/lib/src/si/types/information.dart
+++ b/lib/src/si/types/information.dart
@@ -82,7 +82,18 @@ class Information extends Quantity {
   /// Optionally specify a relative standard [uncert]ainty.
   // ignore:non_constant_identifier_names
   Information({dynamic bits, dynamic B, dynamic kB, dynamic MB, dynamic GB, dynamic TB, double uncert = 0.0})
-      : super(bits ?? (B ?? (kB ?? (MB ?? (GB ?? (TB ?? 0.0))))), Information.bits, uncert);
+      : super(bits ?? (B ?? (kB ?? (MB ?? (GB ?? (TB ?? 0.0))))), 
+              B != null
+                ? Information.bytes
+                : kB != null
+                  ? Information.kilobytes
+                  : MB != null
+                    ? Information.megabytes
+                    : GB != null
+                      ? Information.gigabytes
+                      : TB != null
+                        ? Information.terabytes
+                        : Information.bits, uncert);
 
   Information._internal(dynamic conv) : super._internal(conv, Information.informationDimensions);
 
@@ -94,6 +105,14 @@ class Information extends Quantity {
 
   const Information.constant(Number valueSI, {InformationUnits units, double uncert = 0.0})
       : super.constant(valueSI, Information.informationDimensions, units, uncert);
+
+  @override
+  Quantity operator *(dynamic multiplier) {
+    if (multiplier is num || multiplier is Number) {
+      return super * multiplier;
+    }
+    throw const QuantityException('Expected a num or Number object');
+  }
 }
 
 /// Units acceptable for use in describing Information quantities.

--- a/test/quantity/information_test.dart
+++ b/test/quantity/information_test.dart
@@ -1,0 +1,124 @@
+import 'package:test/test.dart';
+import 'package:quantity/quantity.dart';
+import 'package:quantity/number.dart';
+
+void main() {
+  group('Information', () {
+    test('constructors', () {
+      // Default ctor: bits 0
+      Information i = new Information(bits: 0);
+      expect(i, isNotNull);
+      expect(i.valueSI, Double.zero);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.bits);
+
+      // Default ctor: bits +
+      i = new Information(bits: 8);
+      expect(i, isNotNull);
+      expect(i.valueSI.toInt(), 8);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.bits);
+
+      // Default ctor: bits -
+      i = new Information(bits: -999);
+      expect(i, isNotNull);
+      expect(i.valueSI.toInt(), -999);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.bits);
+
+      // Default ctor: B
+      i = new Information(B: 1);
+      expect(i, isNotNull);
+      expect(i.valueSI.toInt(), 8);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.bytes);
+
+      // Default ctor: kB
+      i = new Information(kB: 1);
+      expect(i, isNotNull);
+      expect(i.valueSI.toInt(), 8 * 1024);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.kilobytes);
+
+      // Default ctor: MB
+      i = new Information(MB: 1);
+      expect(i, isNotNull);
+      expect(i.valueSI.toDouble(), 8 * 1024 * 1024);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.megabytes);
+
+      // Default ctor: GB
+      i = new Information(GB: 1);
+      expect(i, isNotNull);
+      expect(i.valueSI.toDouble(), 8 * 1024 * 1024 * 1024);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.gigabytes);
+
+      // // Default ctor: TB
+      i = new Information(TB: 1);
+      expect(i, isNotNull);
+      expect(i.valueSI.toDouble(), 8 * 1024 * 1024 * 1024 * 1024);
+      expect(i.valueSI is Integer, true);
+      expect(i.dimensions, Information.informationDimensions);
+      expect(i.preferredUnits, Information.terabytes);
+    });
+
+    test('operator - addition', () {
+      dynamicQuantityTyping = true;
+      final Information a = new Information(bits: 5);
+      final Information b = new Information(bits: 64);
+
+      final dynamic c = a + b;
+      expect(c.valueSI.toInt(), 69);
+      expect(c.valueSI is Integer, true);
+      expect(c is Information, true);
+
+      final dynamic d = a + b + b + a;
+      expect(d.valueSI.toInt(), 138);
+      expect(d.valueSI is Integer, true);
+      expect(d is Information, true);
+    });
+
+    test('operator - subtraction', () {
+      dynamicQuantityTyping = true;
+      final Information a = new Information(bits: 64);
+      final Information b = new Information(bits: 5);
+      final Information c = new Information(bits: 13);
+
+      final dynamic aa = a - b;
+      expect(aa.valueSI.toInt(), 59);
+      expect(aa.valueSI is Integer, true);
+      expect(aa is Information, true);
+
+      final dynamic bb = a - c;
+      expect(bb.valueSI.toInt(), 51);
+      expect(bb.valueSI is Integer, true);
+      expect(bb is Information, true);
+    });
+
+    test('operator - multiplication', () {
+      dynamicQuantityTyping = true;
+      final Information a = new Information(bits: 2);
+      final Information b = new Information(bits: 6);
+
+      final dynamic aa = a * 6;
+      expect(aa.valueSI.toInt(), 12);
+      expect(aa.valueSI is Integer, true);
+      expect(aa.dimensions, Information.informationDimensions);
+
+      try {
+        final dynamic bb = a * b;
+        fail('Multiplication should have thrown an exception.');
+      } catch (e) {
+        expect(e is QuantityException, true);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fix the issue #30 
Add unit tests for the Information class. Doing it I found it was possible to multiply an Information quantity with any other quantity. I override the * operator to limit the multiplication to numbers.
I'm also wondering if creating a negative information quantity makes any sense. It may be interesting to forbid using negative values in the constructor.